### PR TITLE
Fix bug setting home and away goals in football game involving my team

### DIFF
--- a/src/model/games/FootballGameInvolvingMyTeam.java
+++ b/src/model/games/FootballGameInvolvingMyTeam.java
@@ -35,17 +35,14 @@ public class FootballGameInvolvingMyTeam extends FootballGame {
 		Matcher matcher = INPUT_PATTERN.matcher(inputResult);
 		if (matcher.find()) {
 
-			int forGoals = Integer.valueOf(matcher.group(1));
-			int againstGoals = Integer.valueOf(matcher.group(2));
+			int homeGoals = Integer.valueOf(matcher.group(1));
+			int awayGoals = Integer.valueOf(matcher.group(2));
 			String homeOrAway = matcher.group(3);
 
 			boolean isHomeTeam = "H".equals(homeOrAway);
 
 			String homeTeam = isHomeTeam ? this.TEAM_NAME : null;
 			String awayTeam = !isHomeTeam ? this.TEAM_NAME : null;
-
-			int homeGoals = isHomeTeam ? forGoals : againstGoals;
-			int awayGoals = !isHomeTeam ? forGoals : againstGoals;
 
 			this.setHomeTeam(homeTeam);
 			this.setAwayTeam(awayTeam);

--- a/test/model/games/FootballGameInvolvingMyTeamTest.java
+++ b/test/model/games/FootballGameInvolvingMyTeamTest.java
@@ -14,6 +14,12 @@ public class FootballGameInvolvingMyTeamTest {
 	}
 
 	@Test
+	public void test_getResultWhenAwayLoss() throws Exception{
+		FootballGameInvolvingMyTeam footballGameInvolvingMyTeam = new FootballGameInvolvingMyTeam("4-1A", "DTS United");
+		Assert.assertEquals(Result.HOME_WIN, footballGameInvolvingMyTeam.getResult());
+	}
+
+	@Test
 	public void test_invalidInputString() {
 		FootballGameInvolvingMyTeam footballGameInvolvingMyTeam = null;
 		try {


### PR DESCRIPTION
This PR fixes a bug setting home and away goals in football game involving my team.

Test 
Create a football result for an away loss for my team. For example the input string to create the football game could be `4-1A`. The points returned from that game for my team should be zero. Before this fix `4-1A` was regarded as an away win for my team.